### PR TITLE
Fix 1.15 elixir compile errors

### DIFF
--- a/lib/html_to_image.ex
+++ b/lib/html_to_image.ex
@@ -21,7 +21,7 @@ defmodule HtmlToImage do
       format - the format of output image file. Default is JPG
   """
   def convert(html, options) do
-    executable = Keyword.get(options, :wkhtmltoimage_path) || executable_path
+    executable = Keyword.get(options, :wkhtmltoimage_path) || executable_path()
     template_name = template_file(html)
     arguments = [
       "--format", Keyword.get(options, :format) || :jpg,
@@ -42,7 +42,7 @@ defmodule HtmlToImage do
   end
 
   defp template_file(data) do
-    template = Path.join(System.tmp_dir, random_filename) <> ".html"
+    template = Path.join(System.tmp_dir, random_filename()) <> ".html"
     {:ok, file} = File.open template, [:write]
     IO.binwrite file, data
     File.close file


### PR DESCRIPTION
small fix for elixir 1.15.0 compiler
```elixir
==> html_to_image
Compiling 1 file (.ex)
error: undefined variable "executable_path"
  lib/html_to_image.ex:24: HtmlToImage.convert/2

error: undefined variable "random_filename"
  lib/html_to_image.ex:45: HtmlToImage.template_file/1

warning: function executable_path/0 is unused
  lib/html_to_image.ex:52: HtmlToImage (module)

warning: function random_filename/1 is unused
  lib/html_to_image.ex:60: HtmlToImage (module)

```